### PR TITLE
#80 Add ScrollController support to multiple pages and widgets

### DIFF
--- a/project/flutter_fridge_app/lib/common/widgets/search_filter_list.dart
+++ b/project/flutter_fridge_app/lib/common/widgets/search_filter_list.dart
@@ -19,6 +19,7 @@ class SearchFilterList<T> extends StatefulWidget {
   final List<FilterDefinition<T>> filters;
   final Widget Function(BuildContext context, T item) itemBuilder;
   final Future<void> Function()? onRefresh;
+  final ScrollController? scrollController;
 
   /// Index of the initially selected chip, where the chip order is:
   ///
@@ -61,6 +62,7 @@ class SearchFilterList<T> extends StatefulWidget {
     this.allFilterFirst = true,
     this.allPredicate,
     this.searchHint = "Search",
+    this.scrollController,
   });
 
   @override
@@ -306,6 +308,7 @@ class _SearchFilterListState<T> extends State<SearchFilterList<T>> {
     final visibleItems = _calculateFilteredItems();
 
     return ListView.separated(
+      controller: widget.scrollController,
       physics: const AlwaysScrollableScrollPhysics(),
       itemCount: visibleItems.length + 1,
       separatorBuilder: (context, index) => const Divider(height: 1),

--- a/project/flutter_fridge_app/lib/main.dart
+++ b/project/flutter_fridge_app/lib/main.dart
@@ -81,6 +81,21 @@ class ShellState extends ConsumerState<Shell> {
   // AlertKeys.outOfStock, or null.
   String? _fridgeInitialFilter;
 
+  // ScrollControllers for each page
+  final ScrollController _homeScrollController = ScrollController();
+  final ScrollController _fridgeScrollController = ScrollController();
+  final ScrollController _reportsScrollController = ScrollController();
+  final ScrollController _settingsScrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _homeScrollController.dispose();
+    _fridgeScrollController.dispose();
+    _reportsScrollController.dispose();
+    _settingsScrollController.dispose();
+    super.dispose();
+  }
+
   void navigateToFridge(String? filterKey) {
     setState(() {
       _idx = 1; // Fridge tab
@@ -88,14 +103,27 @@ class ShellState extends ConsumerState<Shell> {
     });
   }
 
+  void _scrollToTop(ScrollController controller) {
+    if (controller.hasClients) {
+      controller.animateTo(
+        0,
+        duration: const Duration(milliseconds: 500),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final pages = [
-      const HomePage(),
-      FridgePage(initialFilter: _fridgeInitialFilter),
-      const ReportsPage(),
-      const SettingsPage(),
+      HomePage(scrollController: _homeScrollController),
+      FridgePage(
+        initialFilter: _fridgeInitialFilter,
+        scrollController: _fridgeScrollController,
+      ),
+      ReportsPage(scrollController: _reportsScrollController),
+      SettingsPage(scrollController: _settingsScrollController),
     ];
 
     return Scaffold(
@@ -121,6 +149,25 @@ class ShellState extends ConsumerState<Shell> {
           ),
         ],
         onDestinationSelected: (i) {
+          // If tapping the same tab, scroll to top
+          if (_idx == i) {
+            switch (i) {
+              case 0:
+                _scrollToTop(_homeScrollController);
+                break;
+              case 1:
+                _scrollToTop(_fridgeScrollController);
+                break;
+              case 2:
+                _scrollToTop(_reportsScrollController);
+                break;
+              case 3:
+                _scrollToTop(_settingsScrollController);
+                break;
+            }
+            return;
+          }
+
           setState(() {
             _idx = i;
             if (i == 1) {

--- a/project/flutter_fridge_app/lib/pages/fridge.dart
+++ b/project/flutter_fridge_app/lib/pages/fridge.dart
@@ -19,8 +19,9 @@ class FridgePage extends ConsumerStatefulWidget {
   ///
   /// When null, the fridge opens on the "In stock" filter.
   final String? initialFilter;
+  final ScrollController? scrollController;
 
-  const FridgePage({super.key, this.initialFilter});
+  const FridgePage({super.key, this.initialFilter, this.scrollController});
 
   @override
   ConsumerState<FridgePage> createState() => _FridgePageState();
@@ -135,6 +136,7 @@ class _FridgePageState extends ConsumerState<FridgePage> {
           expirySoonDays: _expirySoonDays,
           currencySymbol: currencySymbol,
           initialFilterKey: widget.initialFilter,
+          scrollController: widget.scrollController,
           onRefresh: () => ref.read(itemsNotifierProvider.notifier).refresh(),
           onEdit: _editItem,
           onIncrement: (it) => _adjust(it, 1),

--- a/project/flutter_fridge_app/lib/pages/home.dart
+++ b/project/flutter_fridge_app/lib/pages/home.dart
@@ -9,7 +9,9 @@ import "package:flutter_fridge_app/domain/inventory/alert_keys.dart";
 import "package:flutter_fridge_app/providers/alerts_provider.dart";
 
 class HomePage extends ConsumerWidget {
-  const HomePage({super.key});
+  final ScrollController? scrollController;
+
+  const HomePage({super.key, this.scrollController});
 
   void _openFridgeWithFilter(BuildContext context, String filterKey) {
     final shell = Shell.of(context);
@@ -62,6 +64,7 @@ class HomePage extends ConsumerWidget {
     return RefreshIndicator(
       onRefresh: () => ref.read(alertsNotifierProvider.notifier).refresh(),
       child: ListView(
+        controller: scrollController,
         physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(16),
         children: [

--- a/project/flutter_fridge_app/lib/pages/reports.dart
+++ b/project/flutter_fridge_app/lib/pages/reports.dart
@@ -7,7 +7,9 @@ import "package:flutter_fridge_app/common/widgets/stat_card.dart";
 import "package:flutter_fridge_app/domain/reports/report_range.dart";
 
 class ReportsPage extends ConsumerStatefulWidget {
-  const ReportsPage({super.key});
+  final ScrollController? scrollController;
+
+  const ReportsPage({super.key, this.scrollController});
   @override
   ConsumerState<ReportsPage> createState() => _ReportsPageState();
 }
@@ -68,6 +70,7 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
       body: RefreshIndicator(
         onRefresh: _load,
         child: ListView(
+          controller: widget.scrollController,
           physics: const AlwaysScrollableScrollPhysics(),
           padding: const EdgeInsets.all(16),
           children: [

--- a/project/flutter_fridge_app/lib/pages/settings.dart
+++ b/project/flutter_fridge_app/lib/pages/settings.dart
@@ -17,7 +17,9 @@ import "package:flutter_fridge_app/providers/price_symbol_provider.dart";
 import "package:flutter_fridge_app/providers/theme_provider.dart";
 
 class SettingsPage extends ConsumerStatefulWidget {
-  const SettingsPage({super.key});
+  final ScrollController? scrollController;
+
+  const SettingsPage({super.key, this.scrollController});
 
   @override
   ConsumerState<SettingsPage> createState() => _SettingsPageState();
@@ -567,6 +569,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 80),
             child: ListView(
+              controller: widget.scrollController,
               children: [
                 const SizedBox(height: 16),
                 // Calendar & reporting section - hidden for first release

--- a/project/flutter_fridge_app/lib/widgets/fridge_item_list.dart
+++ b/project/flutter_fridge_app/lib/widgets/fridge_item_list.dart
@@ -15,6 +15,7 @@ class FridgeItemList extends StatelessWidget {
   final Future<void> Function(Item item) onEdit;
   final Future<void> Function(Item item) onIncrement;
   final Future<void> Function(Item item) onDecrementOrDelete;
+  final ScrollController? scrollController;
 
   /// One of: AlertKeys.low, AlertKeys.expiringSoon, AlertKeys.expired,
   /// AlertKeys.outOfStock, or null.
@@ -32,6 +33,7 @@ class FridgeItemList extends StatelessWidget {
     required this.onIncrement,
     required this.onDecrementOrDelete,
     this.initialFilterKey,
+    this.scrollController,
   });
 
   int _initialFilterIndex() {
@@ -97,6 +99,7 @@ class FridgeItemList extends StatelessWidget {
       initialFilterIndex: _initialFilterIndex(),
       onRefresh: onRefresh,
       itemBuilder: _buildTile,
+      scrollController: scrollController,
       // Fridge-specific: we want "In stock" first, and "All" as the last chip.
       showAllFilter: true,
       allLabel: l10n.all,


### PR DESCRIPTION
This pull request introduces scroll-to-top functionality when re-selecting the current tab and refactors multiple pages to accept and use a shared `ScrollController`. This enables consistent scrolling behavior and improves user experience across the app's main pages.