### PR TITLE
#81 Add end-of-list message and configurable bottom spacers to Search…

### DIFF
--- a/project/flutter_fridge_app/lib/common/widgets/search_filter_list.dart
+++ b/project/flutter_fridge_app/lib/common/widgets/search_filter_list.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:flutter_fridge_app/l10n/generated/app_localizations.dart";
 
 class FilterDefinition<T> {
   final String label;
@@ -20,6 +21,17 @@ class SearchFilterList<T> extends StatefulWidget {
   final Widget Function(BuildContext context, T item) itemBuilder;
   final Future<void> Function()? onRefresh;
   final ScrollController? scrollController;
+
+  /// Optional widget to show above the bottom spacer(s). If null, the
+  /// `AppLocalizations.endOfList` string is used.
+  final Widget? endOfListWidget;
+
+  /// Height of the bottom spacer (in logical pixels).
+  final double bottomSpacerHeight;
+
+  /// Number of spacer widgets to append at the end of the list (after the
+  /// header and visible items). Defaults to 2 to preserve previous behavior.
+  final int bottomSpacerCount;
 
   /// Index of the initially selected chip, where the chip order is:
   ///
@@ -63,6 +75,9 @@ class SearchFilterList<T> extends StatefulWidget {
     this.allPredicate,
     this.searchHint = "Search",
     this.scrollController,
+    this.endOfListWidget,
+    this.bottomSpacerHeight = 80,
+    this.bottomSpacerCount = 2,
   });
 
   @override
@@ -299,6 +314,35 @@ class _SearchFilterListState<T> extends State<SearchFilterList<T>> {
     if (index == 0) {
       return _buildHeader();
     }
+    // Bottom spacers (configurable count and height). The first spacer
+    // optionally shows a message widget; any remaining spacers are empty
+    // padding to provide clearance from FABs or system UI.
+    final spacerStartIndex = visibleItems.length + 1;
+    final spacerEndIndex = visibleItems.length + widget.bottomSpacerCount;
+    if (index > visibleItems.length && index <= spacerEndIndex) {
+      final spacerPosition = index - spacerStartIndex; // 0-based within spacers
+      if (spacerPosition == 0) {
+        final Widget message =
+            widget.endOfListWidget ??
+            Container(
+              padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+              child: Center(
+                child: Text(
+                  AppLocalizations.of(context)?.endOfList ??
+                      'All items shown above',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+
+        return message;
+      }
+
+      return SizedBox(height: widget.bottomSpacerHeight);
+    }
 
     final item = visibleItems[index - 1];
     return widget.itemBuilder(context, item);
@@ -310,7 +354,10 @@ class _SearchFilterListState<T> extends State<SearchFilterList<T>> {
     return ListView.separated(
       controller: widget.scrollController,
       physics: const AlwaysScrollableScrollPhysics(),
-      itemCount: visibleItems.length + 1,
+      itemCount:
+          visibleItems.length +
+          1 +
+          widget.bottomSpacerCount, // +1 header + bottom spacers
       separatorBuilder: (context, index) => const Divider(height: 1),
       itemBuilder: (context, index) =>
           _buildListItem(context, index, visibleItems),

--- a/project/flutter_fridge_app/lib/l10n/app_de.arb
+++ b/project/flutter_fridge_app/lib/l10n/app_de.arb
@@ -59,6 +59,7 @@
   "confirmDelete": "Löschen bestätigen",
   "confirmDeleteMessage": "Sind Sie sicher, dass Sie diesen Artikel löschen möchten?",
   "noItems": "Keine Artikel gefunden",
+  "endOfList": "Alle Artikel oben angezeigt",
   "failedToLoadItems": "Fehler beim Laden der Artikel",
   "searchItems": "Artikel suchen...",
   "category": "Kategorie",

--- a/project/flutter_fridge_app/lib/l10n/app_en.arb
+++ b/project/flutter_fridge_app/lib/l10n/app_en.arb
@@ -244,6 +244,10 @@
   "@noItems": {
     "description": "No items message"
   },
+  "endOfList": "All items shown above",
+  "@endOfList": {
+    "description": "Message shown at the bottom of item lists to indicate all items are displayed"
+  },
   "failedToLoadItems": "Failed to load items",
   "@failedToLoadItems": {
     "description": "Error message when items fail to load"

--- a/project/flutter_fridge_app/lib/l10n/app_es.arb
+++ b/project/flutter_fridge_app/lib/l10n/app_es.arb
@@ -59,6 +59,7 @@
   "confirmDelete": "Confirmar eliminación",
   "confirmDeleteMessage": "¿Estás seguro de que quieres eliminar este artículo?",
   "noItems": "No se encontraron artículos",
+  "endOfList": "Todos los artículos mostrados arriba",
   "failedToLoadItems": "Error al cargar los artículos",
   "searchItems": "Buscar artículos...",
   "category": "Categoría",

--- a/project/flutter_fridge_app/lib/l10n/app_fr.arb
+++ b/project/flutter_fridge_app/lib/l10n/app_fr.arb
@@ -59,6 +59,7 @@
   "confirmDelete": "Confirmer la suppression",
   "confirmDeleteMessage": "Êtes-vous sûr de vouloir supprimer cet article ?",
   "noItems": "Aucun article trouvé",
+  "endOfList": "Tous les articles affichés ci-dessus",
   "failedToLoadItems": "Échec du chargement des articles",
   "searchItems": "Rechercher des articles...",
   "category": "Catégorie",

--- a/project/flutter_fridge_app/lib/l10n/app_it.arb
+++ b/project/flutter_fridge_app/lib/l10n/app_it.arb
@@ -57,6 +57,7 @@
   "confirmDelete": "Conferma eliminazione",
   "confirmDeleteMessage": "Sei sicuro di voler eliminare questo articolo?",
   "noItems": "Nessun articolo trovato",
+  "endOfList": "Tutti gli articoli mostrati sopra",
   "failedToLoadItems": "Caricamento articoli non riuscito",
   "searchItems": "Cerca articoli...",
   "category": "Categoria",

--- a/project/flutter_fridge_app/lib/l10n/app_ja.arb
+++ b/project/flutter_fridge_app/lib/l10n/app_ja.arb
@@ -59,6 +59,7 @@
   "confirmDelete": "削除の確認",
   "confirmDeleteMessage": "このアイテムを削除してもよろしいですか？",
   "noItems": "アイテムが見つかりません",
+  "endOfList": "すべてのアイテムを上に表示",
   "failedToLoadItems": "アイテムの読み込みに失敗しました",
   "searchItems": "アイテムを検索...",
   "category": "カテゴリ",

--- a/project/flutter_fridge_app/lib/l10n/app_pt.arb
+++ b/project/flutter_fridge_app/lib/l10n/app_pt.arb
@@ -59,6 +59,7 @@
   "confirmDelete": "Confirmar exclusão",
   "confirmDeleteMessage": "Tem certeza de que deseja excluir este item?",
   "noItems": "Nenhum item encontrado",
+  "endOfList": "Todos os itens mostrados acima",
   "failedToLoadItems": "Falha ao carregar itens",
   "searchItems": "Pesquisar itens...",
   "category": "Categoria",

--- a/project/flutter_fridge_app/lib/l10n/app_ru.arb
+++ b/project/flutter_fridge_app/lib/l10n/app_ru.arb
@@ -59,6 +59,7 @@
   "confirmDelete": "Подтвердить удаление",
   "confirmDeleteMessage": "Вы уверены, что хотите удалить этот товар?",
   "noItems": "Товары не найдены",
+  "endOfList": "Все товары показаны выше",
   "failedToLoadItems": "Не удалось загрузить товары",
   "searchItems": "Поиск товаров...",
   "category": "Категория",

--- a/project/flutter_fridge_app/lib/l10n/app_zh.arb
+++ b/project/flutter_fridge_app/lib/l10n/app_zh.arb
@@ -59,6 +59,8 @@
   "confirmDelete": "确认删除",
   "confirmDeleteMessage": "您确定要删除此项目吗？",
   "noItems": "找不到项目",
+  "endOfList": "所有项目已显示在上方 • 向上滚动查看",
+    "endOfList": "所有项目已显示在上方",
   "failedToLoadItems": "无法加载项目",
   "searchItems": "搜索项目...",
   "category": "类别",

--- a/project/flutter_fridge_app/lib/l10n/app_zh_Hans.arb
+++ b/project/flutter_fridge_app/lib/l10n/app_zh_Hans.arb
@@ -59,6 +59,7 @@
   "confirmDelete": "确认删除",
   "confirmDeleteMessage": "您确定要删除此项目吗？",
   "noItems": "找不到项目",
+  "endOfList": "所有项目已显示在上方",
   "failedToLoadItems": "无法加载项目",
   "searchItems": "搜索项目...",
   "category": "类别",

--- a/project/flutter_fridge_app/lib/l10n/app_zh_Hant.arb
+++ b/project/flutter_fridge_app/lib/l10n/app_zh_Hant.arb
@@ -59,6 +59,7 @@
   "confirmDelete": "確認刪除",
   "confirmDeleteMessage": "您確定要刪除此項目嗎？",
   "noItems": "找不到項目",
+  "endOfList": "所有項目已顯示在上方",
   "failedToLoadItems": "無法載入項目",
   "searchItems": "搜尋項目...",
   "category": "類別",

--- a/project/flutter_fridge_app/lib/l10n/generated/app_localizations.dart
+++ b/project/flutter_fridge_app/lib/l10n/generated/app_localizations.dart
@@ -450,6 +450,12 @@ abstract class AppLocalizations {
   /// **'No items found'**
   String get noItems;
 
+  /// Message shown at the bottom of item lists to indicate all items are displayed
+  ///
+  /// In en, this message translates to:
+  /// **'All items shown above'**
+  String get endOfList;
+
   /// Error message when items fail to load
   ///
   /// In en, this message translates to:

--- a/project/flutter_fridge_app/lib/l10n/generated/app_localizations_de.dart
+++ b/project/flutter_fridge_app/lib/l10n/generated/app_localizations_de.dart
@@ -184,6 +184,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noItems => 'Keine Artikel gefunden';
 
   @override
+  String get endOfList => 'Alle Artikel oben angezeigt';
+
+  @override
   String get failedToLoadItems => 'Fehler beim Laden der Artikel';
 
   @override

--- a/project/flutter_fridge_app/lib/l10n/generated/app_localizations_en.dart
+++ b/project/flutter_fridge_app/lib/l10n/generated/app_localizations_en.dart
@@ -184,6 +184,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noItems => 'No items found';
 
   @override
+  String get endOfList => 'All items shown above';
+
+  @override
   String get failedToLoadItems => 'Failed to load items';
 
   @override

--- a/project/flutter_fridge_app/lib/l10n/generated/app_localizations_es.dart
+++ b/project/flutter_fridge_app/lib/l10n/generated/app_localizations_es.dart
@@ -185,6 +185,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noItems => 'No se encontraron artículos';
 
   @override
+  String get endOfList => 'Todos los artículos mostrados arriba';
+
+  @override
   String get failedToLoadItems => 'Error al cargar los artículos';
 
   @override

--- a/project/flutter_fridge_app/lib/l10n/generated/app_localizations_fr.dart
+++ b/project/flutter_fridge_app/lib/l10n/generated/app_localizations_fr.dart
@@ -186,6 +186,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noItems => 'Aucun article trouvé';
 
   @override
+  String get endOfList => 'Tous les articles affichés ci-dessus';
+
+  @override
   String get failedToLoadItems => 'Échec du chargement des articles';
 
   @override

--- a/project/flutter_fridge_app/lib/l10n/generated/app_localizations_it.dart
+++ b/project/flutter_fridge_app/lib/l10n/generated/app_localizations_it.dart
@@ -185,6 +185,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noItems => 'Nessun articolo trovato';
 
   @override
+  String get endOfList => 'Tutti gli articoli mostrati sopra';
+
+  @override
   String get failedToLoadItems => 'Caricamento articoli non riuscito';
 
   @override

--- a/project/flutter_fridge_app/lib/l10n/generated/app_localizations_ja.dart
+++ b/project/flutter_fridge_app/lib/l10n/generated/app_localizations_ja.dart
@@ -182,6 +182,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get noItems => 'アイテムが見つかりません';
 
   @override
+  String get endOfList => 'すべてのアイテムを上に表示';
+
+  @override
   String get failedToLoadItems => 'アイテムの読み込みに失敗しました';
 
   @override

--- a/project/flutter_fridge_app/lib/l10n/generated/app_localizations_pt.dart
+++ b/project/flutter_fridge_app/lib/l10n/generated/app_localizations_pt.dart
@@ -184,6 +184,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get noItems => 'Nenhum item encontrado';
 
   @override
+  String get endOfList => 'Todos os itens mostrados acima';
+
+  @override
   String get failedToLoadItems => 'Falha ao carregar itens';
 
   @override

--- a/project/flutter_fridge_app/lib/l10n/generated/app_localizations_ru.dart
+++ b/project/flutter_fridge_app/lib/l10n/generated/app_localizations_ru.dart
@@ -184,6 +184,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get noItems => 'Товары не найдены';
 
   @override
+  String get endOfList => 'Все товары показаны выше';
+
+  @override
   String get failedToLoadItems => 'Не удалось загрузить товары';
 
   @override

--- a/project/flutter_fridge_app/lib/l10n/generated/app_localizations_zh.dart
+++ b/project/flutter_fridge_app/lib/l10n/generated/app_localizations_zh.dart
@@ -181,6 +181,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get noItems => '找不到项目';
 
   @override
+  String get endOfList => '所有项目已显示在上方';
+
+  @override
   String get failedToLoadItems => '无法加载项目';
 
   @override
@@ -466,6 +469,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get noItems => '找不到项目';
 
   @override
+  String get endOfList => '所有项目已显示在上方';
+
+  @override
   String get failedToLoadItems => '无法加载项目';
 
   @override
@@ -749,6 +755,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get noItems => '找不到項目';
+
+  @override
+  String get endOfList => '所有項目已顯示在上方';
 
   @override
   String get failedToLoadItems => '無法載入項目';

--- a/project/flutter_fridge_app/test/widgets/search_filter_list_test.dart
+++ b/project/flutter_fridge_app/test/widgets/search_filter_list_test.dart
@@ -43,4 +43,37 @@ void main() {
     expect(find.text("Banana"), findsOneWidget);
     expect(find.text("Apple"), findsNothing);
   });
+
+  testWidgets('renders endOfList widget and bottom spacer height', (
+    WidgetTester tester,
+  ) async {
+    final items = <String>["Apple"];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SearchFilterList<String>(
+            items: items,
+            searchText: (s) => s,
+            filters: [FilterDefinition(label: 'All', predicate: (_) => true)],
+            itemBuilder: (context, s) => ListTile(title: Text(s)),
+            endOfListWidget: const Text('All items shown above'),
+            bottomSpacerHeight: 90,
+            bottomSpacerCount: 2,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Verify the endOfList widget text is present
+    expect(find.text('All items shown above'), findsOneWidget);
+
+    // Verify a SizedBox with the configured height exists (the second spacer)
+    final finder = find.byWidgetPredicate(
+      (w) => w is SizedBox && w.height == 90,
+    );
+    expect(finder, findsOneWidget);
+  });
 }


### PR DESCRIPTION
This pull request enhances the `SearchFilterList` widget to provide a more flexible and user-friendly experience, especially at the end of item lists. It introduces new customisation options for bottom spacers and the end-of-list message, and adds localisation support for the end-of-list text in multiple languages. A new widget test ensures these features work as intended.